### PR TITLE
Use new IDL of enum defined as independent types

### DIFF
--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -4,6 +4,7 @@ import io.iworkflow.core.persistence.SearchAttributeType;
 import io.iworkflow.gen.models.KeyValue;
 import io.iworkflow.gen.models.SearchAttribute;
 import io.iworkflow.gen.models.SearchAttributeKeyAndType;
+import io.iworkflow.gen.models.SearchAttributeValueType;
 import io.iworkflow.gen.models.StateCompletionOutput;
 import io.iworkflow.gen.models.WorkflowGetDataObjectsResponse;
 import io.iworkflow.gen.models.WorkflowGetSearchAttributesResponse;
@@ -63,7 +64,7 @@ public class Client {
      * @param workflowId    the workflowId
      * @param workflowRunId optional runId, can be empty
      * @param <T>           type of the output
-     * @return
+     * @return the output result
      */
     public <T> T getSimpleWorkflowResultWithWait(
             Class<T> valueClass,
@@ -81,8 +82,8 @@ public class Client {
     /**
      * In some cases, a workflow may have more than one completion states
      *
-     * @param workflowId
-     * @param workflowRunId
+     * @param workflowId    workflowId
+     * @param workflowRunId workflowRunId
      * @return a list of the state output for completion states. User code will figure how to use ObjectEncoder to decode the output
      */
     public List<StateCompletionOutput> getComplexWorkflowResultWithWait(
@@ -121,10 +122,10 @@ public class Client {
     }
 
     /**
-     * @param workflowId
-     * @param workflowRunId
-     * @param resetWorkflowTypeAndOptions
-     * @return
+     * @param workflowId workflowId
+     * @param workflowRunId workflowRunId
+     * @param resetWorkflowTypeAndOptions the combination parameter for reset
+     * @return the new runId after reset
      */
     public String resetWorkflow(
             final String workflowId,
@@ -306,12 +307,12 @@ public class Client {
         }
     }
 
-    private SearchAttributeKeyAndType.ValueTypeEnum toGeneratedSearchAttributeType(final SearchAttributeType saType) {
+    private SearchAttributeValueType toGeneratedSearchAttributeType(final SearchAttributeType saType) {
         switch (saType) {
             case INT_64:
-                return SearchAttributeKeyAndType.ValueTypeEnum.INT;
+                return SearchAttributeValueType.INT;
             case KEYWORD:
-                return SearchAttributeKeyAndType.ValueTypeEnum.KEYWORD;
+                return SearchAttributeValueType.KEYWORD;
             default:
                 throw new InternalServiceException("unsupported type");
         }

--- a/src/main/java/io/iworkflow/core/ResetWorkflowTypeAndOptions.java
+++ b/src/main/java/io/iworkflow/core/ResetWorkflowTypeAndOptions.java
@@ -1,6 +1,6 @@
 package io.iworkflow.core;
 
-import io.iworkflow.gen.models.WorkflowResetRequest;
+import io.iworkflow.gen.models.WorkflowResetType;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -8,7 +8,7 @@ import java.util.Optional;
 @Value.Immutable
 public abstract class ResetWorkflowTypeAndOptions {
 
-    public abstract WorkflowResetRequest.ResetTypeEnum getResetType();
+    public abstract WorkflowResetType getResetType();
 
     public abstract Optional<Integer> getHistoryEventId();
 
@@ -24,14 +24,14 @@ public abstract class ResetWorkflowTypeAndOptions {
 
     public static ResetWorkflowTypeAndOptions resetToBeginning(final String reason) {
         return builder()
-                .resetType(WorkflowResetRequest.ResetTypeEnum.BEGINNING)
+                .resetType(WorkflowResetType.BEGINNING)
                 .reason(reason)
                 .build();
     }
 
     public static ResetWorkflowTypeAndOptions resetToHistoryEventId(final int historyEventId, final String reason) {
         return builder()
-                .resetType(WorkflowResetRequest.ResetTypeEnum.HISTORY_EVENT_ID)
+                .resetType(WorkflowResetType.HISTORY_EVENT_ID)
                 .historyEventId(historyEventId)
                 .reason(reason)
                 .build();
@@ -39,7 +39,7 @@ public abstract class ResetWorkflowTypeAndOptions {
 
     public static ResetWorkflowTypeAndOptions resetToHistoryEventId(final String historyEventTime, final String reason) {
         return builder()
-                .resetType(WorkflowResetRequest.ResetTypeEnum.HISTORY_EVENT_ID)
+                .resetType(WorkflowResetType.HISTORY_EVENT_ID)
                 .historyEventTime(historyEventTime)
                 .reason(reason)
                 .build();
@@ -47,7 +47,7 @@ public abstract class ResetWorkflowTypeAndOptions {
 
     public static ResetWorkflowTypeAndOptions resetToStateId(final String stateId, final String reason) {
         return builder()
-                .resetType(WorkflowResetRequest.ResetTypeEnum.STATE_ID)
+                .resetType(WorkflowResetType.STATE_ID)
                 .stateId(stateId)
                 .reason(reason)
                 .build();
@@ -55,7 +55,7 @@ public abstract class ResetWorkflowTypeAndOptions {
 
     public static ResetWorkflowTypeAndOptions resetToStateExecutionId(final String stateExecution, final String reason) {
         return builder()
-                .resetType(WorkflowResetRequest.ResetTypeEnum.STATE_EXECUTION_ID)
+                .resetType(WorkflowResetType.STATE_EXECUTION_ID)
                 .stateExecutionId(stateExecution)
                 .reason(reason)
                 .build();

--- a/src/main/java/io/iworkflow/core/UntypedClient.java
+++ b/src/main/java/io/iworkflow/core/UntypedClient.java
@@ -83,7 +83,7 @@ public class UntypedClient {
      * @param workflowId    the workflowId
      * @param workflowRunId optional runId, can be empty string
      * @param <T>           type of the output
-     * @return
+     * @return the result
      */
     public <T> T getSimpleWorkflowResultWithWait(
             Class<T> valueClass,
@@ -118,7 +118,7 @@ public class UntypedClient {
     /**
      * In some cases, a workflow may have more than one completion states
      *
-     * @param workflowId
+     * @param workflowId    workflowId
      * @param workflowRunId optional runId, can be empty string
      * @return a list of the state output for completion states. User code will figure how to use ObjectEncoder to decode the output
      */
@@ -147,10 +147,10 @@ public class UntypedClient {
     }
 
     /**
-     * @param workflowId
-     * @param workflowRunId
-     * @param resetWorkflowTypeAndOptions
-     * @return
+     * @param workflowId                  workflowId
+     * @param workflowRunId               workflowRunId
+     * @param resetWorkflowTypeAndOptions the combination parameter for reset
+     * @return the new runId after reset
      */
     public String resetWorkflow(
             final String workflowId,
@@ -198,10 +198,10 @@ public class UntypedClient {
     }
 
     /**
-     * @param workflowId
-     * @param workflowRunId
+     * @param workflowId workflowId
+     * @param workflowRunId workflowRunId
      * @param attributeKeys, return all attributes if this is empty or null
-     * @return
+     * @return the response
      */
     public WorkflowGetDataObjectsResponse getAnyWorkflowDataObjects(
             final String workflowId,

--- a/src/main/java/io/iworkflow/core/WorkerService.java
+++ b/src/main/java/io/iworkflow/core/WorkerService.java
@@ -15,6 +15,7 @@ import io.iworkflow.gen.models.EncodedObject;
 import io.iworkflow.gen.models.InterStateChannelPublishing;
 import io.iworkflow.gen.models.KeyValue;
 import io.iworkflow.gen.models.SearchAttribute;
+import io.iworkflow.gen.models.SearchAttributeValueType;
 import io.iworkflow.gen.models.WorkflowStateDecideRequest;
 import io.iworkflow.gen.models.WorkflowStateDecideResponse;
 import io.iworkflow.gen.models.WorkflowStateStartRequest;
@@ -193,14 +194,14 @@ public class WorkerService {
             final SearchAttribute attr = new SearchAttribute()
                     .key(key)
                     .stringValue(sa)
-                    .valueType(SearchAttribute.ValueTypeEnum.KEYWORD);
+                    .valueType(SearchAttributeValueType.KEYWORD);
             sas.add(attr);
         });
         upsertToServerInt64AttributeMap.forEach((key, sa) -> {
             final SearchAttribute attr = new SearchAttribute()
                     .key(key)
                     .integerValue(sa)
-                    .valueType(SearchAttribute.ValueTypeEnum.INT);
+                    .valueType(SearchAttributeValueType.INT);
             sas.add(attr);
         });
         return sas;

--- a/src/main/java/io/iworkflow/core/Workflow.java
+++ b/src/main/java/io/iworkflow/core/Workflow.java
@@ -18,6 +18,8 @@ public interface Workflow {
      * defines the states of the workflow. A state represents a step of the workflow state machine.
      * A state can execute some commands (signal/timer) and wait for result
      * See more details in the {@link WorkflowState} definition.
+     *
+     * @return all the state definitions
      */
     List<StateDef> getStates();
 
@@ -32,6 +34,7 @@ public interface Workflow {
      * Search attributes can be read/upsert in WorkflowState start/decide API
      * Search attributes can also be read by GetSearchAttributes Client API by external applications
      * External applications can also use "SearchWorkflow" API to find workflows by SQL-like query
+     * @return the persistence schema
      */
     default List<PersistenceFieldDef> getPersistenceSchema() {
         return Collections.emptyList();
@@ -48,6 +51,7 @@ public interface Workflow {
      * <p>
      * InterStateChannel is for synchronization communications between WorkflowStates.
      * E.g. WorkflowStateA will continue after receiving a value from WorkflowStateB
+     * @return the communication schema
      */
     default List<CommunicationMethodDef> getCommunicationSchema() {
         return Collections.emptyList();
@@ -58,6 +62,7 @@ public interface Workflow {
      * which should be the case for most scenarios.
      * <p>
      * In case of dynamic workflow implementation, return customized values based on constructor input.
+     * @return the workflow type
      */
     default String getWorkflowType() {
         return "";

--- a/src/main/java/io/iworkflow/core/WorkflowOptions.java
+++ b/src/main/java/io/iworkflow/core/WorkflowOptions.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public abstract class WorkflowOptions {
     public abstract Integer getWorkflowTimeoutSeconds();
 
-    public abstract Optional<io.iworkflow.gen.models.WorkflowStartOptions.WorkflowIDReusePolicyEnum> getWorkflowIdReusePolicy();
+    public abstract Optional<io.iworkflow.gen.models.WorkflowIDReusePolicy> getWorkflowIdReusePolicy();
 
     public abstract Optional<String> getCronSchedule();
 

--- a/src/main/java/io/iworkflow/core/WorkflowState.java
+++ b/src/main/java/io/iworkflow/core/WorkflowState.java
@@ -9,11 +9,14 @@ import io.iworkflow.gen.models.WorkflowStateOptions;
 public interface WorkflowState<I> {
     /**
      * a unique identifier of the state
+     *
+     * @return the Id of the state(must be unique in any workflow definition)
      */
     String getStateId();
 
     /**
      * This input type is needed for deserializing data back into Java object
+     * @return the type of the state input
      */
     Class<I> getInputType();
 
@@ -69,6 +72,7 @@ public interface WorkflowState<I> {
      * MaxInternalSeconds:100
      * MaximumAttempts: 0
      * BackoffCoefficient: 2
+     * @return the optional options
      */
     default WorkflowStateOptions getStateOptions() {
         return null;

--- a/src/main/java/io/iworkflow/core/command/CommandRequest.java
+++ b/src/main/java/io/iworkflow/core/command/CommandRequest.java
@@ -1,5 +1,6 @@
 package io.iworkflow.core.command;
 
+import io.iworkflow.gen.models.DeciderTriggerType;
 import org.immutables.value.Value;
 
 import java.util.Arrays;
@@ -9,17 +10,17 @@ import java.util.List;
 public abstract class CommandRequest {
     public abstract List<BaseCommand> getCommands();
 
-    public abstract io.iworkflow.gen.models.CommandRequest.DeciderTriggerTypeEnum getDeciderTriggerType();
+    public abstract DeciderTriggerType getDeciderTriggerType();
 
     // empty command request will jump to decide stage immediately.
     // It doesn't matter whatever DeciderTriggerType is provided. But it's required so we have to put one.
-    public static final CommandRequest empty = ImmutableCommandRequest.builder().deciderTriggerType(io.iworkflow.gen.models.CommandRequest.DeciderTriggerTypeEnum.ALL_COMMAND_COMPLETED).build();
+    public static final CommandRequest empty = ImmutableCommandRequest.builder().deciderTriggerType(DeciderTriggerType.ALL_COMMAND_COMPLETED).build();
 
     public static CommandRequest forAllCommandCompleted(final BaseCommand... commands) {
-        return ImmutableCommandRequest.builder().addAllCommands(Arrays.asList(commands)).deciderTriggerType(io.iworkflow.gen.models.CommandRequest.DeciderTriggerTypeEnum.ALL_COMMAND_COMPLETED).build();
+        return ImmutableCommandRequest.builder().addAllCommands(Arrays.asList(commands)).deciderTriggerType(DeciderTriggerType.ALL_COMMAND_COMPLETED).build();
     }
 
     public static CommandRequest forAnyCommandCompleted(final BaseCommand... commands) {
-        return ImmutableCommandRequest.builder().addAllCommands(Arrays.asList(commands)).deciderTriggerType(io.iworkflow.gen.models.CommandRequest.DeciderTriggerTypeEnum.ANY_COMMAND_COMPLETED).build();
+        return ImmutableCommandRequest.builder().addAllCommands(Arrays.asList(commands)).deciderTriggerType(DeciderTriggerType.ANY_COMMAND_COMPLETED).build();
     }
 }

--- a/src/main/java/io/iworkflow/core/command/TimerCommandResult.java
+++ b/src/main/java/io/iworkflow/core/command/TimerCommandResult.java
@@ -1,12 +1,12 @@
 package io.iworkflow.core.command;
 
-import io.iworkflow.gen.models.TimerResult;
+import io.iworkflow.gen.models.TimerStatus;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class TimerCommandResult {
 
-    public abstract TimerResult.TimerStatusEnum getTimerStatus();
+    public abstract TimerStatus getTimerStatus();
 
     public abstract String getCommandId();
 }

--- a/src/main/java/io/iworkflow/core/communication/Communication.java
+++ b/src/main/java/io/iworkflow/core/communication/Communication.java
@@ -5,8 +5,8 @@ public interface Communication {
     /**
      * Publish a value to an interstate Channel
      *
-     * @param channelName
-     * @param value
+     * @param channelName the channel name to send value
+     * @param value       the value to be sent
      */
     void publishInterstateChannel(String channelName, Object value);
 }

--- a/src/main/java/io/iworkflow/core/communication/InterStateChannelCommandResult.java
+++ b/src/main/java/io/iworkflow/core/communication/InterStateChannelCommandResult.java
@@ -1,6 +1,6 @@
 package io.iworkflow.core.communication;
 
-import io.iworkflow.gen.models.InterStateChannelResult;
+import io.iworkflow.gen.models.InterStateChannelRequestStatus;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -14,5 +14,5 @@ public abstract class InterStateChannelCommandResult {
 
     public abstract Optional<Object> getValue();
 
-    public abstract InterStateChannelResult.RequestStatusEnum getRequestStatusEnum();
+    public abstract InterStateChannelRequestStatus getRequestStatusEnum();
 }

--- a/src/main/java/io/iworkflow/core/communication/SignalCommandResult.java
+++ b/src/main/java/io/iworkflow/core/communication/SignalCommandResult.java
@@ -1,6 +1,6 @@
 package io.iworkflow.core.communication;
 
-import io.iworkflow.gen.models.SignalResult;
+import io.iworkflow.gen.models.SignalRequestStatus;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -14,5 +14,5 @@ public abstract class SignalCommandResult {
 
     public abstract Optional<Object> getSignalValue();
 
-    public abstract SignalResult.SignalRequestStatusEnum getSignalRequestStatusEnum();
+    public abstract SignalRequestStatus getSignalRequestStatusEnum();
 }

--- a/src/main/java/io/iworkflow/core/persistence/StateLocals.java
+++ b/src/main/java/io/iworkflow/core/persistence/StateLocals.java
@@ -6,8 +6,8 @@ public interface StateLocals {
      * Usually it's for passing from State Start API to State Decide API
      * User code must make sure using the same type for both get and set
      *
-     * @param key
-     * @param value
+     * @param key   the key of the stateLocal(scope of the state execution)
+     * @param value the value
      */
     void setStateLocal(String key, Object value);
 
@@ -15,10 +15,10 @@ public interface StateLocals {
      * Retrieve a local state attribute
      * User code must make sure using the same type for both get and set
      *
-     * @param key
-     * @param type
-     * @param <T>
-     * @return
+     * @param key the key of the stateLocal(scope of the state execution)
+     * @param type the value type
+     * @param <T> the value type
+     * @return the value
      */
     <T> T getStateLocal(String key, Class<T> type);
 

--- a/src/test/java/io/iworkflow/integ/BasicTest.java
+++ b/src/test/java/io/iworkflow/integ/BasicTest.java
@@ -4,7 +4,7 @@ import io.iworkflow.core.Client;
 import io.iworkflow.core.ClientOptions;
 import io.iworkflow.core.ImmutableWorkflowOptions;
 import io.iworkflow.core.WorkflowOptions;
-import io.iworkflow.gen.models.WorkflowStartOptions;
+import io.iworkflow.gen.models.WorkflowIDReusePolicy;
 import io.iworkflow.integ.basic.BasicWorkflow;
 import io.iworkflow.integ.basic.BasicWorkflowState1;
 import io.iworkflow.integ.basic.EmptyInputWorkflow;
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 public class BasicTest {
@@ -31,7 +30,7 @@ public class BasicTest {
         final String wfId = "basic-test-id" + System.currentTimeMillis() / 1000;
         final WorkflowOptions startOptions = ImmutableWorkflowOptions.builder()
                 .workflowTimeoutSeconds(10)
-                .workflowIdReusePolicy(Optional.of(WorkflowStartOptions.WorkflowIDReusePolicyEnum.ALLOW_DUPLICATE))
+                .workflowIdReusePolicy(WorkflowIDReusePolicy.REJECT_DUPLICATE)
                 .build();
         final Integer input = 0;
         client.startWorkflow(BasicWorkflow.class, BasicWorkflowState1.StateId, input, wfId, startOptions);
@@ -46,7 +45,7 @@ public class BasicTest {
         final String wfId = "empty-input-test-id" + System.currentTimeMillis() / 1000;
         final WorkflowOptions startOptions = ImmutableWorkflowOptions.builder()
                 .workflowTimeoutSeconds(10)
-                .workflowIdReusePolicy(Optional.of(io.iworkflow.gen.models.WorkflowStartOptions.WorkflowIDReusePolicyEnum.ALLOW_DUPLICATE))
+                .workflowIdReusePolicy(WorkflowIDReusePolicy.ALLOW_DUPLICATE)
                 .build();
         
         //client.StartWorkflow(EmptyInputWorkflow.class, EmptyInputWorkflowState1.StateId, null, wfId, startOptions);

--- a/src/test/java/io/iworkflow/integ/interstatechannel/BasicInterStateChannelWorkflowState1.java
+++ b/src/test/java/io/iworkflow/integ/interstatechannel/BasicInterStateChannelWorkflowState1.java
@@ -9,7 +9,7 @@ import io.iworkflow.core.communication.Communication;
 import io.iworkflow.core.communication.InterStateChannelCommand;
 import io.iworkflow.core.communication.InterStateChannelCommandResult;
 import io.iworkflow.core.persistence.Persistence;
-import io.iworkflow.gen.models.InterStateChannelResult;
+import io.iworkflow.gen.models.InterStateChannelRequestStatus;
 
 public class BasicInterStateChannelWorkflowState1 implements WorkflowState<Integer> {
     public static final String STATE_ID = "inter-state-s1";
@@ -48,7 +48,7 @@ public class BasicInterStateChannelWorkflowState1 implements WorkflowState<Integ
         Integer output = input + (Integer) result1.getValue().get();
 
         final InterStateChannelCommandResult result2 = commandResults.getAllInterStateChannelCommandResult().get(1);
-        if (result2.getRequestStatusEnum() != InterStateChannelResult.RequestStatusEnum.WAITING) {
+        if (result2.getRequestStatusEnum() != InterStateChannelRequestStatus.WAITING) {
             throw new RuntimeException("the second command should be waiting");
         }
         return StateDecision.gracefulCompleteWorkflow(output);

--- a/src/test/java/io/iworkflow/integ/signal/BasicSignalWorkflowState1.java
+++ b/src/test/java/io/iworkflow/integ/signal/BasicSignalWorkflowState1.java
@@ -9,7 +9,7 @@ import io.iworkflow.core.communication.Communication;
 import io.iworkflow.core.communication.SignalCommand;
 import io.iworkflow.core.communication.SignalCommandResult;
 import io.iworkflow.core.persistence.Persistence;
-import io.iworkflow.gen.models.SignalResult;
+import io.iworkflow.gen.models.SignalRequestStatus;
 
 public class BasicSignalWorkflowState1 implements WorkflowState<Integer> {
     public static final String STATE_ID = "signal-s1";
@@ -51,7 +51,7 @@ public class BasicSignalWorkflowState1 implements WorkflowState<Integer> {
         Integer output = input + (Integer) signalCommandResult.getSignalValue().get();
 
         SignalCommandResult signalCommandResult2 = commandResults.getAllSignalCommandResults().get(1);
-        if (signalCommandResult2.getSignalRequestStatusEnum() != SignalResult.SignalRequestStatusEnum.WAITING) {
+        if (signalCommandResult2.getSignalRequestStatusEnum() != SignalRequestStatus.WAITING) {
             throw new RuntimeException("the second signal should be waiting");
         }
         return StateDecision.gracefulCompleteWorkflow(output);


### PR DESCRIPTION
Because of https://github.com/OpenAPITools/openapi-generator/pull/2897#issuecomment-1358839510 we have to refactor the IDL. 
Luckily, this won't cause any compatibility issues. It's just a local refactor for the idl without any compatibility changes. 

Tested using old Java SDK with new server and new Java SDK with old server