### PR TITLE
Add new APIs without the workflowRunId

### DIFF
--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -408,16 +408,15 @@ public class Client {
     }
 
     /**
-     * Stop a workflow, this is essentially terminate the workflow gracefully
-     * The workflow status will be CANCELED
+     * Stop a workflow with options
      *
      * @param workflowId    required
-     * @param workflowRunId optional, can be empty
+     * @param options       optional, can be null. If not set, the workflow status will be CANCELED
      */
     public void stopWorkflow(
             final String workflowId,
-            final String workflowRunId) {
-        stopWorkflow(workflowId, workflowRunId, null);
+            final StopWorkflowOptions options) {
+        stopWorkflow(workflowId, "", options);
     }
 
     /**

--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -319,6 +319,15 @@ public class Client {
         return getComplexWorkflowResultWithWait(workflowId, "");
     }
 
+    /**
+     * Emit a signal message for the workflow object to receive from external sources
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param workflowRunId     optional, can be empty
+     * @param signalChannelName required
+     * @param signalValue       optional, can be null
+     */
     public void signalWorkflow(
             final Class<? extends ObjectWorkflow> workflowClass,
             final String workflowId,
@@ -343,9 +352,25 @@ public class Client {
     }
 
     /**
-     * @param workflowId workflowId
-     * @param workflowRunId workflowRunId
-     * @param resetWorkflowTypeAndOptions the combination parameter for reset
+     * Emit a signal message for the workflow object to receive from external sources
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param signalChannelName required
+     * @param signalValue       optional, can be null
+     */
+    public void signalWorkflow(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId,
+            final String signalChannelName,
+            final Object signalValue) {
+        signalWorkflow(workflowClass, workflowId, "", signalChannelName, signalValue);
+    }
+
+    /**
+     * @param workflowId                    required
+     * @param workflowRunId                 optional, can be empty
+     * @param resetWorkflowTypeAndOptions   required, the combination parameter for reset
      * @return the new runId after reset
      */
     public String resetWorkflow(
@@ -353,28 +378,27 @@ public class Client {
             final String workflowRunId,
             final ResetWorkflowTypeAndOptions resetWorkflowTypeAndOptions
     ) {
-
         return unregisteredClient.resetWorkflow(workflowId, workflowRunId, resetWorkflowTypeAndOptions);
     }
 
     /**
-     * Stop a workflow, this is essentially terminate the workflow gracefully
-     *
-     * @param workflowId    required
-     * @param workflowRunId optional, can be empty
+     * @param workflowId                    required
+     * @param resetWorkflowTypeAndOptions   required, the combination parameter for reset
+     * @return the new runId after reset
      */
-    public void stopWorkflow(
+    public String resetWorkflow(
             final String workflowId,
-            final String workflowRunId) {
-        unregisteredClient.stopWorkflow(workflowId, workflowRunId);
+            final ResetWorkflowTypeAndOptions resetWorkflowTypeAndOptions
+    ) {
+        return resetWorkflow(workflowId, "", resetWorkflowTypeAndOptions);
     }
 
     /**
      * Stop a workflow with options
      *
      * @param workflowId    required
-     * @param workflowRunId optional
-     * @param options       optional
+     * @param workflowRunId optional, can be empty
+     * @param options       optional, can be null. If not set, the workflow status will be CANCELED
      */
     public void stopWorkflow(
             final String workflowId,
@@ -383,6 +407,38 @@ public class Client {
         unregisteredClient.stopWorkflow(workflowId, workflowRunId, options);
     }
 
+    /**
+     * Stop a workflow, this is essentially terminate the workflow gracefully
+     * The workflow status will be CANCELED
+     *
+     * @param workflowId    required
+     * @param workflowRunId optional, can be empty
+     */
+    public void stopWorkflow(
+            final String workflowId,
+            final String workflowRunId) {
+        stopWorkflow(workflowId, workflowRunId, null);
+    }
+
+    /**
+     * Stop a workflow, this is essentially terminate the workflow gracefully
+     * The workflow status will be CANCELED
+     *
+     * @param workflowId    required
+     */
+    public void stopWorkflow(final String workflowId) {
+        stopWorkflow(workflowId, "", null);
+    }
+
+    /**
+     * Get specified data attributes (by keys) of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param workflowRunId     optional, can be empty
+     * @param keys              required, cannot be empty or null
+     * @return the data attributes
+     */
     public Map<String, Object> getWorkflowDataObjects(
             final Class<? extends ObjectWorkflow> workflowClass,
             final String workflowId,
@@ -395,11 +451,47 @@ public class Client {
         return doGetWorkflowDataObjects(workflowClass, workflowId, workflowRunId, keys);
     }
 
+    /**
+     * Get specified data attributes (by keys) of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param keys              required, cannot be empty or null
+     * @return the data attributes
+     */
+    public Map<String, Object> getWorkflowDataObjects(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId,
+            List<String> keys) {
+        return getWorkflowDataObjects(workflowClass, workflowId, "", keys);
+    }
+
+    /**
+     * Get all the data attributes of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param workflowRunId     optional, can be empty
+     * @return the data attributes
+     */
     public Map<String, Object> getAllDataObjects(
             final Class<? extends ObjectWorkflow> workflowClass,
             final String workflowId,
             final String workflowRunId) {
         return doGetWorkflowDataObjects(workflowClass, workflowId, workflowRunId, null);
+    }
+
+    /**
+     * Get all the data attributes of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @return the data attributes
+     */
+    public Map<String, Object> getAllDataObjects(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId) {
+        return getAllDataObjects(workflowClass, workflowId, "");
     }
 
     private Map<String, Object> doGetWorkflowDataObjects(
@@ -471,8 +563,8 @@ public class Client {
      * create a new stub for invoking RPC
      *
      * @param workflowClassForRpc the class of defining the RPCs to invoke
-     * @param workflowId          workflowId is required
-     * @param workflowRunId       optional
+     * @param workflowId          required
+     * @param workflowRunId       optional, can be empty
      * @param <T>                 the class of defining the RPCs to invoke
      * @return the result of the RPC
      */
@@ -513,6 +605,18 @@ public class Client {
         }
 
         return result;
+    }
+
+    /**
+     * create a new stub for invoking RPC
+     *
+     * @param workflowClassForRpc the class of defining the RPCs to invoke
+     * @param workflowId          required
+     * @param <T>                 the class of defining the RPCs to invoke
+     * @return the result of the RPC
+     */
+    public <T> T newRpcStub(Class<T> workflowClassForRpc, String workflowId) {
+        return newRpcStub(workflowClassForRpc, workflowId, "");
     }
 
     /**
@@ -559,6 +663,15 @@ public class Client {
         rpcStubMethod.execute(null, null, null);
     }
 
+    /**
+     * Get specified search attributes (by attributeKeys) of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param workflowRunId     optional, can be empty
+     * @param attributeKeys     required, cannot be empty or null
+     * @return the search attributes
+     */
     public Map<String, Object> getWorkflowSearchAttributes(
             final Class<? extends ObjectWorkflow> workflowClass,
             final String workflowId,
@@ -571,11 +684,54 @@ public class Client {
     }
 
     /**
+     * Get specified search attributes (by attributeKeys) of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param attributeKeys     required, cannot be empty or null
+     * @return the search attributes
+     */
+    public Map<String, Object> getWorkflowSearchAttributes(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId,
+            List<String> attributeKeys) {
+        return getWorkflowSearchAttributes(workflowClass, workflowId, "", attributeKeys);
+    }
+
+    /**
+     * Get all the search attributes of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @param workflowRunId     optional, can be empty
+     * @return the search attributes
+     */
+    public Map<String, Object> getAllSearchAttributes(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId,
+            final String workflowRunId) {
+        return doGetWorkflowSearchAttributes(workflowClass, workflowId, workflowRunId, null);
+    }
+
+    /**
+     * Get all the search attributes of a workflow
+     *
+     * @param workflowClass     required
+     * @param workflowId        required
+     * @return the search attributes
+     */
+    public Map<String, Object> getAllSearchAttributes(
+            final Class<? extends ObjectWorkflow> workflowClass,
+            final String workflowId) {
+        return getAllSearchAttributes(workflowClass, workflowId, "");
+    }
+
+    /**
      * Describe a workflow to get its info.
      * If the workflow does not exist, throw the WORKFLOW_NOT_EXISTS_SUB_STATUS exception.
      *
      * @param workflowId    required
-     * @param workflowRunId optional
+     * @param workflowRunId optional, can be empty
      * @return the workflow's info
      */
     public WorkflowInfo describeWorkflow(
@@ -587,11 +743,16 @@ public class Client {
                 .build();
     }
 
-    public Map<String, Object> getAllSearchAttributes(
-            final Class<? extends ObjectWorkflow> workflowClass,
-            final String workflowId,
-            final String workflowRunId) {
-        return doGetWorkflowSearchAttributes(workflowClass, workflowId, workflowRunId, null);
+    /**
+     * Describe a workflow to get its info.
+     * If the workflow does not exist, throw the WORKFLOW_NOT_EXISTS_SUB_STATUS exception.
+     *
+     * @param workflowId    required
+     * @return the workflow's info
+     */
+    public WorkflowInfo describeWorkflow(
+            final String workflowId) {
+        return describeWorkflow(workflowId, "");
     }
 
     private Map<String, Object> doGetWorkflowSearchAttributes(

--- a/src/main/java/io/iworkflow/core/UnregisteredClient.java
+++ b/src/main/java/io/iworkflow/core/UnregisteredClient.java
@@ -350,6 +350,18 @@ public class UnregisteredClient {
     }
 
     /**
+     * Stop a workflow, this is essentially cancel the workflow gracefully
+     *
+     * @param workflowId    required
+     * @param workflowRunId optional
+     */
+    public void stopWorkflow(
+            final String workflowId,
+            final String workflowRunId) {
+        stopWorkflow(workflowId, workflowRunId, null);
+    }
+
+    /**
      * Stop a workflow with options
      *
      * @param workflowId    required

--- a/src/main/java/io/iworkflow/core/UnregisteredClient.java
+++ b/src/main/java/io/iworkflow/core/UnregisteredClient.java
@@ -350,18 +350,6 @@ public class UnregisteredClient {
     }
 
     /**
-     * Stop a workflow, this is essentially cancel the workflow gracefully
-     *
-     * @param workflowId    required
-     * @param workflowRunId optional
-     */
-    public void stopWorkflow(
-            final String workflowId,
-            final String workflowRunId) {
-        stopWorkflow(workflowId, workflowRunId, null);
-    }
-
-    /**
      * Stop a workflow with options
      *
      * @param workflowId    required

--- a/src/test/java/io/iworkflow/integ/BasicTest.java
+++ b/src/test/java/io/iworkflow/integ/BasicTest.java
@@ -147,7 +147,7 @@ public class BasicTest {
         final String wfId = "wf-get-workflow-status-running-test-id" + System.currentTimeMillis() / 1000;
 
         client.startWorkflow(BasicWorkflow.class, wfId, 10, null, null);
-        final WorkflowInfo workflowInfo = client.describeWorkflow(wfId, "");
+        final WorkflowInfo workflowInfo = client.describeWorkflow(wfId);
         Assertions.assertEquals(WorkflowStatus.RUNNING, workflowInfo.getWorkflowStatus());
     }
 }

--- a/src/test/java/io/iworkflow/integ/NoStartStateTest.java
+++ b/src/test/java/io/iworkflow/integ/NoStartStateTest.java
@@ -57,7 +57,7 @@ public class NoStartStateTest {
 
         Assertions.assertEquals(RPC_OUTPUT, rpcOutput);
 
-        client.stopWorkflow(wfId, "");
+        client.stopWorkflow(wfId, null);
     }
 
     @Test

--- a/src/test/java/io/iworkflow/integ/PersistenceTest.java
+++ b/src/test/java/io/iworkflow/integ/PersistenceTest.java
@@ -33,27 +33,42 @@ public class PersistenceTest {
         final String runId = client.startWorkflow(
                 BasicPersistenceWorkflow.class, wfId, 10, "start");
         final String output = client.getSimpleWorkflowResultWithWait(String.class, wfId);
+        Assertions.assertEquals("test-value-2", output);
+
         Map<String, Object> map =
                 client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 "query-start-query-decide", map.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+
+        // test no runId
+        Map<String, Object> map2 =
+                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+        Assertions.assertEquals(
+                "query-start-query-decide", map2.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+
         Map<String, Object> allDataObjects = client.getAllDataObjects(BasicPersistenceWorkflow.class, wfId, runId);
         Assertions.assertEquals(3, allDataObjects.size());
-
         Assertions.assertEquals("query-start-query-decide", allDataObjects.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
 
-        Assertions.assertEquals("test-value-2", output);
+        // test no runId
+        Map<String, Object> allDataObjects2 = client.getAllDataObjects(BasicPersistenceWorkflow.class, wfId);
+        Assertions.assertEquals(3, allDataObjects2.size());
+        Assertions.assertEquals("query-start-query-decide", allDataObjects2.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
 
         final Map<String, Object> searchAttributes1 = client.getWorkflowSearchAttributes(BasicPersistenceWorkflow.class,
                 wfId, "", Arrays.asList(TEST_SEARCH_ATTRIBUTE_KEYWORD, TEST_SEARCH_ATTRIBUTE_INT));
-
-        final Map<String, Object> searchAttributes2 = client.getAllSearchAttributes(BasicPersistenceWorkflow.class,
-                wfId, "");
-
         Assertions.assertEquals(ImmutableMap.builder()
                 .put(TEST_SEARCH_ATTRIBUTE_INT, 2L)
                 .put(TEST_SEARCH_ATTRIBUTE_KEYWORD, "keyword-2")
                 .build(), searchAttributes1);
+
+        // test no runId
+        final Map<String, Object> searchAttributes2 = client.getWorkflowSearchAttributes(BasicPersistenceWorkflow.class,
+                wfId, Arrays.asList(TEST_SEARCH_ATTRIBUTE_KEYWORD, TEST_SEARCH_ATTRIBUTE_INT));
+        Assertions.assertEquals(ImmutableMap.builder()
+                .put(TEST_SEARCH_ATTRIBUTE_INT, 2L)
+                .put(TEST_SEARCH_ATTRIBUTE_KEYWORD, "keyword-2")
+                .build(), searchAttributes2);
 
         // TODO fix
         // Expected :{CustomIntField=2, CustomKeywordField=keyword-2, CustomDatetimeField=2023-04-17T21:17:49-00:00}

--- a/src/test/java/io/iworkflow/integ/RpcTest.java
+++ b/src/test/java/io/iworkflow/integ/RpcTest.java
@@ -227,7 +227,7 @@ public class RpcTest {
             Assertions.assertEquals("java.lang.RuntimeException", errResp.getOriginalWorkerErrorType());
             Assertions.assertEquals("worker API error, status:501, errorType:java.lang.RuntimeException", errResp.getDetail());
         }
-        client.stopWorkflow(wfId, "");
+        client.stopWorkflow(wfId, null);
     }
 
 }

--- a/src/test/java/io/iworkflow/integ/RpcTest.java
+++ b/src/test/java/io/iworkflow/integ/RpcTest.java
@@ -94,7 +94,7 @@ public class RpcTest {
         final String runId = client.startWorkflow(
                 RpcWorkflow.class, wfId, 10, 999);
 
-        final RpcWorkflow rpcStub = client.newRpcStub(RpcWorkflow.class, wfId, "");
+        final RpcWorkflow rpcStub = client.newRpcStub(RpcWorkflow.class, wfId);
         final Long rpcOutput = client.invokeRPC(rpcStub::testRpcFunc0);
 
         Assertions.assertEquals(RPC_OUTPUT, rpcOutput);

--- a/src/test/java/io/iworkflow/integ/SignalTest.java
+++ b/src/test/java/io/iworkflow/integ/SignalTest.java
@@ -38,6 +38,10 @@ public class SignalTest {
         client.signalWorkflow(
                 BasicSignalWorkflow.class, wfId, runId, SIGNAL_CHANNEL_NAME_1, Integer.valueOf(2));
 
+        // test no runId
+        client.signalWorkflow(
+                BasicSignalWorkflow.class, wfId, SIGNAL_CHANNEL_NAME_1, Integer.valueOf(2));
+
         // test sending null signal
         client.signalWorkflow(
                 BasicSignalWorkflow.class, wfId, runId, SIGNAL_CHANNEL_NAME_3, null);

--- a/src/test/java/io/iworkflow/integ/WorkflowUncompletedTest.java
+++ b/src/test/java/io/iworkflow/integ/WorkflowUncompletedTest.java
@@ -99,6 +99,29 @@ public class WorkflowUncompletedTest {
     }
 
     @Test
+    public void testWorkflowCanceledWhenNotProvidingRunId() throws InterruptedException {
+        final Client client = new Client(WorkflowRegistry.registry, ClientOptions.localDefault);
+        final String wfId = "testWorkflowTimeout" + System.currentTimeMillis() / 1000;
+        final Integer input = 1;
+        final String runId = client.startWorkflow(
+                BasicSignalWorkflow.class, wfId, 10, input);
+
+        client.stopWorkflow(wfId);
+
+        try {
+            client.getSimpleWorkflowResultWithWait(Integer.class, wfId);
+        } catch (WorkflowUncompletedException e) {
+            Assertions.assertEquals(runId, e.getRunId());
+            Assertions.assertEquals(WorkflowStatus.CANCELED, e.getClosedStatus());
+            Assertions.assertNull(e.getErrorSubType());
+            Assertions.assertNull(e.getErrorMessage());
+            Assertions.assertEquals(0, e.getStateResultsSize());
+            return;
+        }
+        Assertions.fail("no exception caught");
+    }
+
+    @Test
     public void testWorkflowTerminated() throws InterruptedException {
         final Client client = new Client(WorkflowRegistry.registry, ClientOptions.localDefault);
         final String wfId = "testWorkflowTerminated" + System.currentTimeMillis() / 1000;

--- a/src/test/java/io/iworkflow/integ/WorkflowUncompletedTest.java
+++ b/src/test/java/io/iworkflow/integ/WorkflowUncompletedTest.java
@@ -83,7 +83,7 @@ public class WorkflowUncompletedTest {
         final String runId = client.startWorkflow(
                 BasicSignalWorkflow.class, wfId, 10, input);
 
-        client.stopWorkflow(wfId, "");
+        client.stopWorkflow(wfId);
 
         try {
             client.getSimpleWorkflowResultWithWait(Integer.class, wfId);


### PR DESCRIPTION
This MR did:
- Added necessary javadoc to related public methods with workflowRunId
- Added new APIs (without workflowRunId) for the related public methods
- Leave the skipTimer methods now because currently there are 4 skipTimer methods already. If we added the related new APIs without the runId, then there will be 8 different versions, which might be too many.