### PR TITLE
Support weak typed data attributes, and rename related methods

### DIFF
--- a/src/main/java/io/iworkflow/core/Registry.java
+++ b/src/main/java/io/iworkflow/core/Registry.java
@@ -162,10 +162,10 @@ public class Registry {
         }
 
         for (final DataAttributeDef dataAttributeField : fields) {
-            if (!dataAttributeField.isPrefix()) {
-                addDataAttributeToStore(dataAttributeField, workflowType, dataAttributeKeyToTypeStore);
-            } else {
+            if (dataAttributeField.isPrefix()) {
                 addDataAttributeToStore(dataAttributeField, workflowType, dataAttributePrefixToTypeStore);
+            } else {
+                addDataAttributeToStore(dataAttributeField, workflowType, dataAttributeKeyToTypeStore);
             }
         }
     }

--- a/src/main/java/io/iworkflow/core/WorkerService.java
+++ b/src/main/java/io/iworkflow/core/WorkerService.java
@@ -268,9 +268,13 @@ public class WorkerService {
         return results;
     }
 
-    private DataAttributesRWImpl createDataObjectsRW(String workflowType, List<KeyValue> keyValues) {
+    private DataAttributesRWImpl createDataObjectsRW(final String workflowType, final List<KeyValue> keyValues) {
         final Map<String, EncodedObject> map = toMap(keyValues);
-        return new DataAttributesRWImpl(registry.getDataAttributeKeyToTypeMap(workflowType), map, workerOptions.getObjectEncoder());
+        return new DataAttributesRWImpl(
+                registry.getDataAttributeKeyToTypeMap(workflowType),
+                registry.getDataAttributePrefixToTypeMap(workflowType),
+                map,
+                workerOptions.getObjectEncoder());
     }
 
     private Map<String, EncodedObject> toMap(final List<KeyValue> keyValues) {

--- a/src/main/java/io/iworkflow/core/persistence/DataAttributeDef.java
+++ b/src/main/java/io/iworkflow/core/persistence/DataAttributeDef.java
@@ -5,11 +5,21 @@ import org.immutables.value.Value;
 @Value.Immutable
 public abstract class DataAttributeDef implements PersistenceFieldDef {
     public abstract Class getDataAttributeType();
+    public abstract Boolean isPrefix();
 
-    public static DataAttributeDef create(Class dataType, String key) {
+    public static DataAttributeDef create(final Class dataType, final String key) {
         return ImmutableDataAttributeDef.builder()
                 .key(key)
                 .dataAttributeType(dataType)
+                .isPrefix(false)
+                .build();
+    }
+
+    public static DataAttributeDef createByPrefix(final Class dataType, final String key) {
+        return ImmutableDataAttributeDef.builder()
+                .key(key)
+                .dataAttributeType(dataType)
+                .isPrefix(true)
                 .build();
     }
 }

--- a/src/main/java/io/iworkflow/core/persistence/DataAttributeDef.java
+++ b/src/main/java/io/iworkflow/core/persistence/DataAttributeDef.java
@@ -7,6 +7,14 @@ public abstract class DataAttributeDef implements PersistenceFieldDef {
     public abstract Class getDataAttributeType();
     public abstract Boolean isPrefix();
 
+    /**
+     * iWF will verify if the key has been registered for the data attribute created using this method,
+     * allowing users to create only one data attribute with the same key and data type.
+     *
+     * @param dataType  required.
+     * @param key       required. The unique key.
+     * @return a data attribute definition
+     */
     public static DataAttributeDef create(final Class dataType, final String key) {
         return ImmutableDataAttributeDef.builder()
                 .key(key)
@@ -15,9 +23,19 @@ public abstract class DataAttributeDef implements PersistenceFieldDef {
                 .build();
     }
 
-    public static DataAttributeDef createByPrefix(final Class dataType, final String key) {
+    /**
+     * iWF now supports dynamically created data attributes with a shared prefix and the same data type.
+     * (E.g., dynamically created data attributes of type String can be named with a common prefix like: data_attribute_prefix_1: "one", data_attribute_prefix_2: "two")
+     * iWF will verify if the prefix has been registered for data attributes created using this method,
+     * allowing users to create multiple data attributes with the same prefix and data type.
+     *
+     * @param dataType      required.
+     * @param keyPrefix     required. The common prefix of a set of keys to be created later.
+     * @return a data attribute definition
+     */
+    public static DataAttributeDef createByPrefix(final Class dataType, final String keyPrefix) {
         return ImmutableDataAttributeDef.builder()
-                .key(key)
+                .key(keyPrefix)
                 .dataAttributeType(dataType)
                 .isPrefix(true)
                 .build();

--- a/src/main/java/io/iworkflow/core/utils/DataAttributeUtils.java
+++ b/src/main/java/io/iworkflow/core/utils/DataAttributeUtils.java
@@ -1,0 +1,47 @@
+package io.iworkflow.core.utils;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class DataAttributeUtils {
+    public static Boolean isValidDataAttributeKey(
+            final String key,
+            final Map<String, Class<?>> dataAttributeKeyToTypeMap,
+            final Map<String, Class<?>> dataAttributePrefixToTypeMap) {
+
+        if (dataAttributeKeyToTypeMap.containsKey(key)) {
+            return true;
+        }
+
+        final Optional<String> first = dataAttributePrefixToTypeMap.keySet().stream()
+                .filter(key::startsWith)
+                .findFirst();
+
+        return first.isPresent();
+    }
+
+    public static Class<?> getDataAttributeType(
+            final String key,
+            final Map<String, Class<?>> dataAttributeKeyToTypeMap,
+            final Map<String, Class<?>> dataAttributePrefixToTypeMap) {
+
+        if (dataAttributeKeyToTypeMap.containsKey(key)) {
+            return dataAttributeKeyToTypeMap.get(key);
+        }
+
+        final Optional<String> first = dataAttributePrefixToTypeMap.keySet().stream()
+                .filter(key::startsWith)
+                .findFirst();
+
+        if (first.isPresent()) {
+            return dataAttributePrefixToTypeMap.get(first.get());
+        }
+
+        throw new IllegalArgumentException(
+                String.format(
+                        "Data attribute not registered: %s",
+                        key
+                )
+        );
+    }
+}

--- a/src/test/java/io/iworkflow/integ/PersistenceTest.java
+++ b/src/test/java/io/iworkflow/integ/PersistenceTest.java
@@ -14,10 +14,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_DATE_TIME;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_INT;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_KEYWORD;
-import static io.iworkflow.integ.persistence.BasicPersistenceWorkflowState1.testDateTimeValue;
 
 public class PersistenceTest {
 
@@ -36,24 +34,33 @@ public class PersistenceTest {
         Assertions.assertEquals("test-value-2", output);
 
         Map<String, Object> map =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId,
+                        Arrays.asList(
+                                BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY,
+                                BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "1",
+                                BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "2"));
         Assertions.assertEquals(
                 "query-start-query-decide", map.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+        Assertions.assertEquals(
+                11L, map.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "1"));
+        Assertions.assertNull(map.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "2"));
 
         // test no runId
         Map<String, Object> map2 =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 "query-start-query-decide", map2.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
 
-        Map<String, Object> allDataObjects = client.getAllDataObjects(BasicPersistenceWorkflow.class, wfId, runId);
-        Assertions.assertEquals(3, allDataObjects.size());
+        Map<String, Object> allDataObjects = client.getAllDataAttributes(BasicPersistenceWorkflow.class, wfId, runId);
+        Assertions.assertEquals(4, allDataObjects.size());
         Assertions.assertEquals("query-start-query-decide", allDataObjects.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+        Assertions.assertEquals(11L, allDataObjects.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "1"));
 
         // test no runId
-        Map<String, Object> allDataObjects2 = client.getAllDataObjects(BasicPersistenceWorkflow.class, wfId);
-        Assertions.assertEquals(3, allDataObjects2.size());
+        Map<String, Object> allDataObjects2 = client.getAllDataAttributes(BasicPersistenceWorkflow.class, wfId);
+        Assertions.assertEquals(4, allDataObjects2.size());
         Assertions.assertEquals("query-start-query-decide", allDataObjects2.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+        Assertions.assertEquals(11L, allDataObjects.get(BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX + "1"));
 
         final Map<String, Object> searchAttributes1 = client.getWorkflowSearchAttributes(BasicPersistenceWorkflow.class,
                 wfId, "", Arrays.asList(TEST_SEARCH_ATTRIBUTE_KEYWORD, TEST_SEARCH_ATTRIBUTE_INT));

--- a/src/test/java/io/iworkflow/integ/RpcTest.java
+++ b/src/test/java/io/iworkflow/integ/RpcTest.java
@@ -71,7 +71,7 @@ public class RpcTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, RPC_INPUT)
@@ -106,7 +106,7 @@ public class RpcTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, HARDCODED_STR)
@@ -140,7 +140,7 @@ public class RpcTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, RPC_INPUT)
@@ -173,7 +173,7 @@ public class RpcTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, HARDCODED_STR)

--- a/src/test/java/io/iworkflow/integ/RpcWithMemoTest.java
+++ b/src/test/java/io/iworkflow/integ/RpcWithMemoTest.java
@@ -83,7 +83,7 @@ public class RpcWithMemoTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, RPC_INPUT)
@@ -118,7 +118,7 @@ public class RpcWithMemoTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, HARDCODED_STR)
@@ -152,7 +152,7 @@ public class RpcWithMemoTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, RPC_INPUT)
@@ -185,7 +185,7 @@ public class RpcWithMemoTest {
 
         // data attrs
         Map<String, Object> dataAttrs =
-                client.getWorkflowDataObjects(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
+                client.getWorkflowDataAttributes(BasicPersistenceWorkflow.class, wfId, runId, Arrays.asList(BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY));
         Assertions.assertEquals(
                 ImmutableMap.builder()
                         .put(TEST_DATA_OBJECT_KEY, HARDCODED_STR)

--- a/src/test/java/io/iworkflow/integ/persistence/BasicPersistenceWorkflow.java
+++ b/src/test/java/io/iworkflow/integ/persistence/BasicPersistenceWorkflow.java
@@ -19,6 +19,7 @@ public class BasicPersistenceWorkflow implements ObjectWorkflow {
     public static final String TEST_DATA_OBJECT_MODEL_1 = "data-obj-2";
 
     public static final String TEST_DATA_OBJECT_MODEL_2 = "data-obj-3";
+    public static final String TEST_DATA_OBJECT_PREFIX = "data-obj-prefix-";
 
     public static final String TEST_SEARCH_ATTRIBUTE_KEYWORD = "CustomKeywordField";
     public static final String TEST_SEARCH_ATTRIBUTE_INT = "CustomIntField";
@@ -36,6 +37,7 @@ public class BasicPersistenceWorkflow implements ObjectWorkflow {
                 DataAttributeDef.create(String.class, TEST_DATA_OBJECT_KEY),
                 DataAttributeDef.create(Context.class, TEST_DATA_OBJECT_MODEL_1),
                 DataAttributeDef.create(FakContextImpl.class, TEST_DATA_OBJECT_MODEL_2),
+                DataAttributeDef.createByPrefix(Long.class, TEST_DATA_OBJECT_PREFIX),
                 SearchAttributeDef.create(SearchAttributeValueType.INT, TEST_SEARCH_ATTRIBUTE_INT),
                 SearchAttributeDef.create(SearchAttributeValueType.KEYWORD, TEST_SEARCH_ATTRIBUTE_KEYWORD),
                 SearchAttributeDef.create(SearchAttributeValueType.DATETIME, TEST_SEARCH_ATTRIBUTE_DATE_TIME)

--- a/src/test/java/io/iworkflow/integ/persistence/BasicPersistenceWorkflowState1.java
+++ b/src/test/java/io/iworkflow/integ/persistence/BasicPersistenceWorkflowState1.java
@@ -11,11 +11,13 @@ import io.iworkflow.core.communication.Communication;
 import io.iworkflow.core.persistence.Persistence;
 import io.iworkflow.integ.basic.FakContextImpl;
 
+import javax.validation.constraints.AssertTrue;
 import java.util.Arrays;
 
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_DATA_OBJECT_KEY;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_DATA_OBJECT_MODEL_1;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_DATA_OBJECT_MODEL_2;
+import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_DATA_OBJECT_PREFIX;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_DATE_TIME;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_INT;
 import static io.iworkflow.integ.persistence.BasicPersistenceWorkflow.TEST_SEARCH_ATTRIBUTE_KEYWORD;
@@ -44,6 +46,9 @@ public class BasicPersistenceWorkflowState1 implements WorkflowState<String> {
         // but it's not allowed to set a parent to child
         //persistence.setDataObject(TEST_DATA_OBJECT_MODEL_2, new io.iworkflow.gen.models.Context());
         persistence.setDataAttribute(TEST_DATA_OBJECT_MODEL_2, new FakContextImpl());
+
+        // set dynamic data attribute with the registered prefix
+        persistence.setDataAttribute(TEST_DATA_OBJECT_PREFIX + "1", 11L);
 
         persistence.setStateExecutionLocal("test-key", "test-value-1");
         persistence.recordEvent("event-1", "event-1");
@@ -75,6 +80,14 @@ public class BasicPersistenceWorkflowState1 implements WorkflowState<String> {
         // but it's allowed to assign child to parent
         persistence.getDataAttribute(TEST_DATA_OBJECT_MODEL_2, io.iworkflow.gen.models.Context.class);
         persistence.getDataAttribute(TEST_DATA_OBJECT_MODEL_2, FakContextImpl.class);
+
+        // dynamically created data attribute with the registered prefix
+        final Long validDataAttributeWithPrefix = persistence.getDataAttribute(TEST_DATA_OBJECT_PREFIX + "1", Long.class);
+        assert validDataAttributeWithPrefix == 11L;
+
+        // return null for non-dynamically created data attribute with the registered prefix
+        final Long nonValidDataAttributeWithPrefix = persistence.getDataAttribute(TEST_DATA_OBJECT_PREFIX + "2", Long.class);
+        assert nonValidDataAttributeWithPrefix == null;
 
         String testVal2 = persistence.getStateExecutionLocal("test-key", String.class);
         if (testVal2.equals("test-value-1")) {


### PR DESCRIPTION
This MR did:
1. support weak typed data attributes by managing a isPrefix field in DataAttributeDef and a new registry field.
2. rename related getDataObject methods to getDataAttribute.