### PR TITLE
Fix waitForWorkflow API for workflow with multiple thread results

### DIFF
--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -260,13 +260,14 @@ public class Client {
      */
     public void waitForWorkflowCompletion(
             final String workflowId) {
-        this.getSimpleWorkflowResultWithWait(Void.class, workflowId);
+        getComplexWorkflowResultWithWait(workflowId);
     }
 
     /**
-     * A long poll API to wait for the workflow completion
-     * For most cases, a workflow only has one result(one completion state).
-     * Use this API to retrieve the output of the state with waiting for the workflow to complete.
+     * A long poll API to wait for the workflow completion and return single result
+     * This only works for a workflow only has one result(one completion state).
+     * If the workflow has multiple completion states, use getComplexWorkflowResultWithWait.
+     * This API to retrieve the output of the state with waiting for the workflow to complete.
      * If the workflow is not COMPLETED, throw the {@link WorkflowUncompletedException}.
      *
      * @param valueClass    required, the type class of the output

--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -253,7 +253,9 @@ public class Client {
     }
 
     /**
-     * A long poll API to wait for the workflow completion
+     * A long poll API to wait for the workflow completion.
+     * Due to the limit of REST API, it will only wait for 30 seconds for the workflow to complete.
+     * (configurable in ClientOptions.LongPollApiMaxWaitTimeSeconds)
      * If the workflow is not COMPLETED, throw the {@link WorkflowUncompletedException}.
      *
      * @param workflowId    required, the workflowId

--- a/src/main/java/io/iworkflow/core/WorkflowIdReusePolicy.java
+++ b/src/main/java/io/iworkflow/core/WorkflowIdReusePolicy.java
@@ -1,4 +1,0 @@
-package io.iworkflow.core;
-
-public enum WorkflowIdReusePolicy {
-}

--- a/src/main/java/io/iworkflow/core/WorkflowIdReusePolicy.java
+++ b/src/main/java/io/iworkflow/core/WorkflowIdReusePolicy.java
@@ -1,0 +1,4 @@
+package io.iworkflow.core;
+
+public enum WorkflowIdReusePolicy {
+}


### PR DESCRIPTION
It's broken when workflow has multiple different completion results. 