### PR TITLE
Added .github/PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### Description
+<description>
+
+### Related Issue
+Closes #<issue_number>
+
+### Checklist
+- [ ] Code compiles correctly
+- [ ] Tests for the changes have been added
+- [ ] All tests passing


### PR DESCRIPTION
Adding a `.github/[PULL_REQUEST_TEMPLATE.md` file to help with ensuring we link our PR with the issues we're working on

This is just a suggestion for PRs - I'm not suggesting anything mandatory

(More info in [Github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository))