### PR TITLE
IWF-117: Rename WorkflowNotExistsOrOpenException -> NoRunningWorkflowException

### DIFF
--- a/src/main/java/io/iworkflow/core/IwfHttpException.java
+++ b/src/main/java/io/iworkflow/core/IwfHttpException.java
@@ -2,8 +2,8 @@ package io.iworkflow.core;
 
 import feign.FeignException;
 import io.iworkflow.core.exceptions.LongPollTimeoutException;
+import io.iworkflow.core.exceptions.NoRunningWorkflowException;
 import io.iworkflow.core.exceptions.WorkflowAlreadyStartedException;
-import io.iworkflow.core.exceptions.WorkflowNotExistsOrOpenException;
 import io.iworkflow.gen.models.EncodedObject;
 import io.iworkflow.gen.models.ErrorResponse;
 import io.iworkflow.gen.models.ErrorSubStatus;
@@ -71,7 +71,7 @@ public abstract class IwfHttpException extends RuntimeException {
                 case WORKFLOW_ALREADY_STARTED_SUB_STATUS:
                     return new WorkflowAlreadyStartedException(clientSideException);
                 case WORKFLOW_NOT_EXISTS_SUB_STATUS:
-                    return new WorkflowNotExistsOrOpenException(clientSideException);
+                    return new NoRunningWorkflowException(clientSideException);
                 default:
                     return clientSideException;
             }

--- a/src/main/java/io/iworkflow/core/exceptions/NoRunningWorkflowException.java
+++ b/src/main/java/io/iworkflow/core/exceptions/NoRunningWorkflowException.java
@@ -1,0 +1,10 @@
+package io.iworkflow.core.exceptions;
+
+import io.iworkflow.core.ClientSideException;
+
+public class NoRunningWorkflowException extends ClientSideException {
+    public NoRunningWorkflowException(
+            final ClientSideException exception) {
+        super(exception);
+    }
+}

--- a/src/main/java/io/iworkflow/core/exceptions/NoRunningWorkflowException.java
+++ b/src/main/java/io/iworkflow/core/exceptions/NoRunningWorkflowException.java
@@ -2,7 +2,7 @@ package io.iworkflow.core.exceptions;
 
 import io.iworkflow.core.ClientSideException;
 
-public class NoRunningWorkflowException extends ClientSideException {
+public class NoRunningWorkflowException extends WorkflowNotExistsOrOpenException {
     public NoRunningWorkflowException(
             final ClientSideException exception) {
         super(exception);

--- a/src/main/java/io/iworkflow/core/exceptions/WorkflowNotExistsOrOpenException.java
+++ b/src/main/java/io/iworkflow/core/exceptions/WorkflowNotExistsOrOpenException.java
@@ -2,6 +2,10 @@ package io.iworkflow.core.exceptions;
 
 import io.iworkflow.core.ClientSideException;
 
+/**
+ * @deprecated Use NoRunningWorkflowException instead
+ */
+@Deprecated
 public class WorkflowNotExistsOrOpenException extends ClientSideException {
     public WorkflowNotExistsOrOpenException(
             final ClientSideException exception) {

--- a/src/test/java/io/iworkflow/integ/BasicTest.java
+++ b/src/test/java/io/iworkflow/integ/BasicTest.java
@@ -8,8 +8,8 @@ import io.iworkflow.core.UnregisteredWorkflowOptions;
 import io.iworkflow.core.WorkflowDefinitionException;
 import io.iworkflow.core.WorkflowInfo;
 import io.iworkflow.core.WorkflowOptions;
+import io.iworkflow.core.exceptions.NoRunningWorkflowException;
 import io.iworkflow.core.exceptions.WorkflowAlreadyStartedException;
-import io.iworkflow.core.exceptions.WorkflowNotExistsOrOpenException;
 import io.iworkflow.gen.models.Context;
 import io.iworkflow.gen.models.ErrorSubStatus;
 import io.iworkflow.gen.models.IDReusePolicy;
@@ -77,7 +77,7 @@ public class BasicTest {
 
         try {
             client.getSimpleWorkflowResultWithWait(Integer.class, "a wrong workflowId");
-        } catch (WorkflowNotExistsOrOpenException e) {
+        } catch (NoRunningWorkflowException e) {
             Assertions.assertEquals(ErrorSubStatus.WORKFLOW_NOT_EXISTS_SUB_STATUS, e.getErrorSubStatus());
             Assertions.assertEquals(400, e.getStatusCode());
             return;
@@ -159,7 +159,7 @@ public class BasicTest {
 
         try {
             client.describeWorkflow(wfId, "");
-        } catch (final WorkflowNotExistsOrOpenException e) {
+        } catch (final NoRunningWorkflowException e) {
             Assertions.assertEquals(ErrorSubStatus.WORKFLOW_NOT_EXISTS_SUB_STATUS, e.getErrorSubStatus());
             Assertions.assertEquals(400, e.getStatusCode());
         }

--- a/src/test/java/io/iworkflow/integ/SignalTest.java
+++ b/src/test/java/io/iworkflow/integ/SignalTest.java
@@ -2,7 +2,7 @@ package io.iworkflow.integ;
 
 import io.iworkflow.core.Client;
 import io.iworkflow.core.ClientOptions;
-import io.iworkflow.core.exceptions.WorkflowNotExistsOrOpenException;
+import io.iworkflow.core.exceptions.NoRunningWorkflowException;
 import io.iworkflow.gen.models.ErrorSubStatus;
 import io.iworkflow.integ.signal.BasicSignalWorkflow;
 import io.iworkflow.integ.signal.BasicSignalWorkflowState2;
@@ -61,7 +61,7 @@ public class SignalTest {
         try {
             client.signalWorkflow(
                     BasicSignalWorkflow.class, wfId, runId, SIGNAL_CHANNEL_NAME_1, Integer.valueOf(2));
-        } catch (WorkflowNotExistsOrOpenException e) {
+        } catch (NoRunningWorkflowException e) {
             Assertions.assertEquals(ErrorSubStatus.WORKFLOW_NOT_EXISTS_SUB_STATUS, e.getErrorSubStatus());
             Assertions.assertEquals(400, e.getStatusCode());
             return;


### PR DESCRIPTION
Rename WorkflowNotExistsOrOpenException -> NoRunningWorkflowException

### Description


### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing

### Related Issue
Closes #<issue_number>