### PR TITLE
IWF-138: Add waitForKey to WorkflowWaitForStateCompletion

### DIFF
--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -1009,13 +1009,30 @@ public class Client {
      * If the state is not COMPLETED, throw the {@link ClientSideException} with the sub status of {@link ErrorSubStatus#LONG_POLL_TIME_OUT_SUB_STATUS}
      * @param workflowId the workflowId
      * @param stateClass the state class
+     * @param waitForKey key provided by the client and to identity workflow
+     */
+    public void waitForStateExecutionCompletion(
+            final String workflowId,
+            final Class<? extends WorkflowState> stateClass,
+            final String waitForKey) {
+        final String stateId = WorkflowState.getDefaultStateId(stateClass);
+        unregisteredClient.waitForStateExecutionCompletion(workflowId, stateId, waitForKey);
+    }
+
+    /**
+     * A long poll API to wait for the completion of the state. This only waits for the first completion.
+     * Note 1 The stateCompletion and stateExecutionNumber to wait for must be registered on starting workflow due to limitation in https://github.com/indeedeng/iwf/issues/349
+     * Note 2 The max polling time is configured as clientOptions as the Feign client timeout(default to 10s)
+     * If the state is not COMPLETED, throw the {@link ClientSideException} with the sub status of {@link ErrorSubStatus#LONG_POLL_TIME_OUT_SUB_STATUS}
+     * @param workflowId the workflowId
+     * @param stateClass the state class
      * @param stateExecutionNumber the state execution number. E.g. if it's 2, it means the 2nd execution of the state
      */
     public void waitForStateExecutionCompletion(
             final String workflowId,
             final Class<? extends WorkflowState> stateClass,
             final int stateExecutionNumber) {
-        final String stateExecutionId= WorkflowState.getStateExecutionId(stateClass, stateExecutionNumber);
+        final String stateExecutionId = WorkflowState.getStateExecutionId(stateClass, stateExecutionNumber);
         unregisteredClient.waitForStateExecutionCompletion(workflowId, stateExecutionId);
     }
 }

--- a/src/main/java/io/iworkflow/core/StateDecision.java
+++ b/src/main/java/io/iworkflow/core/StateDecision.java
@@ -164,7 +164,18 @@ public abstract class StateDecision {
      * @return state decision
      */
     public static <I> StateDecision singleNextState(final Class<? extends WorkflowState<I>> stateClass, final I stateInput) {
-        return singleNextState(stateClass, stateInput, null);
+        return singleNextState(stateClass.getSimpleName(), stateInput, null);
+    }
+
+    /**
+     * @param <I>        Class type of the WorkflowState input
+     * @param stateClass required
+     * @param stateInput optional, can be null
+     * @param waitForKey key awaited at state completion
+     * @return state decision
+     */
+    public static <I> StateDecision singleNextState(final Class<? extends WorkflowState<I>> stateClass, final I stateInput, final String waitForKey) {
+        return singleNextState(stateClass.getSimpleName(), stateInput, null, waitForKey);
     }
 
     /**
@@ -183,7 +194,7 @@ public abstract class StateDecision {
      * @return state decision
      */
     public static <I> StateDecision singleNextState(final Class<? extends WorkflowState<I>> stateClass) {
-        return singleNextState(stateClass, null, null);
+        return singleNextState(stateClass.getSimpleName(), null, null);
     }
 
     /**
@@ -197,6 +208,21 @@ public abstract class StateDecision {
     public static StateDecision singleNextState(final String stateId, final Object stateInput, final WorkflowStateOptions stateOptionsOverride) {
         return ImmutableStateDecision.builder().nextStates(Arrays.asList(
                 StateMovement.create(stateId, stateInput, stateOptionsOverride)
+        )).build();
+    }
+
+    /**
+     * use the other one with WorkflowState class param if the stateId is provided by default, to make your code cleaner
+     *
+     * @param stateId              required. StateId of next state
+     * @param stateInput           optional, can be null. Input for next state
+     * @param stateOptionsOverride optional, can be null. It is used to override the defined one in the State class
+     * @param waitForKey           key awaited at state completion
+     * @return state decision
+     */
+    public static StateDecision singleNextState(final String stateId, final Object stateInput, final WorkflowStateOptions stateOptionsOverride, final String waitForKey) {
+        return ImmutableStateDecision.builder().nextStates(Arrays.asList(
+                StateMovement.create(stateId, stateInput, stateOptionsOverride, waitForKey)
         )).build();
     }
 

--- a/src/main/java/io/iworkflow/core/StateMovement.java
+++ b/src/main/java/io/iworkflow/core/StateMovement.java
@@ -14,6 +14,8 @@ public abstract class StateMovement {
 
     public abstract Optional<WorkflowStateOptions> getStateOptionsOverride();
 
+    public abstract Optional<String> getWaitForKey();
+
     public final static String RESERVED_STATE_ID_PREFIX = "_SYS_";
     private final static String GRACEFUL_COMPLETING_WORKFLOW_STATE_ID = "_SYS_GRACEFUL_COMPLETING_WORKFLOW";
     private final static String FORCE_COMPLETING_WORKFLOW_STATE_ID = "_SYS_FORCE_COMPLETING_WORKFLOW";
@@ -105,6 +107,29 @@ public abstract class StateMovement {
 
         if (stateOptionsOverride != null) {
             builder.stateOptionsOverride(stateOptionsOverride);
+        }
+
+        return builder.build();
+    }
+
+    public static StateMovement create(final String stateId, final Object stateInput, final WorkflowStateOptions stateOptionsOverride, final String waitForKey) {
+        if (stateId.startsWith(RESERVED_STATE_ID_PREFIX)) {
+            throw new WorkflowDefinitionException("Cannot use reserved stateId prefix for your stateId");
+        }
+
+        final ImmutableStateMovement.Builder builder = ImmutableStateMovement.builder()
+                .stateId(stateId);
+
+        if (stateInput != null) {
+            builder.stateInput(stateInput);
+        }
+
+        if (stateOptionsOverride != null) {
+            builder.stateOptionsOverride(stateOptionsOverride);
+        }
+
+        if (waitForKey != null) {
+            builder.waitForKey(waitForKey);
         }
 
         return builder.build();

--- a/src/main/java/io/iworkflow/core/UnregisteredClient.java
+++ b/src/main/java/io/iworkflow/core/UnregisteredClient.java
@@ -32,7 +32,6 @@ import io.iworkflow.gen.models.WorkflowStartResponse;
 import io.iworkflow.gen.models.WorkflowStatus;
 import io.iworkflow.gen.models.WorkflowStopRequest;
 import io.iworkflow.gen.models.WorkflowWaitForStateCompletionRequest;
-import io.iworkflow.gen.models.WorkflowWaitForStateCompletionResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -379,7 +378,26 @@ public class UnregisteredClient {
             request.waitTimeSeconds(clientOptions.getLongPollApiMaxWaitTimeSeconds().get());
         }
 
-        final WorkflowWaitForStateCompletionResponse response;
+        try {
+            defaultApi.apiV1WorkflowWaitForStateCompletionPost(request);
+        } catch (final FeignException.FeignClientException exp) {
+            throw IwfHttpException.fromFeignException(clientOptions.getObjectEncoder(), exp);
+        }
+    }
+
+    public void waitForStateExecutionCompletion(
+            final String workflowId,
+            final String stateId,
+            final String waitForKey) {
+        final WorkflowWaitForStateCompletionRequest request = new WorkflowWaitForStateCompletionRequest()
+                .stateId(stateId)
+                .waitForKey(waitForKey)
+                .workflowId(workflowId);
+
+        if(clientOptions.getLongPollApiMaxWaitTimeSeconds().isPresent()) {
+            request.waitTimeSeconds(clientOptions.getLongPollApiMaxWaitTimeSeconds().get());
+        }
+
         try {
             defaultApi.apiV1WorkflowWaitForStateCompletionPost(request);
         } catch (final FeignException.FeignClientException exp) {

--- a/src/main/java/io/iworkflow/core/mapper/StateMovementMapper.java
+++ b/src/main/java/io/iworkflow/core/mapper/StateMovementMapper.java
@@ -43,6 +43,8 @@ public class StateMovementMapper {
             if (stateOptions != null) {
                 movement.stateOptions(stateOptions);
             }
+
+            stateMovement.getWaitForKey().ifPresent(movement::waitForKey);
         }
         return movement;
     }

--- a/src/test/java/io/iworkflow/integ/basic/BasicWorkflowState1.java
+++ b/src/test/java/io/iworkflow/integ/basic/BasicWorkflowState1.java
@@ -36,6 +36,6 @@ public class BasicWorkflowState1 implements WorkflowState<Integer> {
         }
 
         final int output = input + 1;
-        return StateDecision.singleNextState(BasicWorkflowState2.class, output);
+        return StateDecision.singleNextState(BasicWorkflowState2.class, output, "testKey");
     }
 }


### PR DESCRIPTION
### Description
Add waitForKey to WorkflowWaitForStateCompletion

### Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added
- [x] All tests passing
- [x] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Depends on
https://github.com/indeedeng/iwf/pull/440