### PR TITLE
Adjust RpcLocking test contention to avoid test being flacky

### DIFF
--- a/src/test/java/io/iworkflow/integ/RpcTest.java
+++ b/src/test/java/io/iworkflow/integ/RpcTest.java
@@ -46,13 +46,7 @@ public class RpcTest {
         final Client client = new Client(WorkflowRegistry.registry, ClientOptions.localDefault);
         final String wfId = "testRPCLocking" + System.currentTimeMillis() / 1000;
         client.startWorkflow(
-                NoStateWorkflow.class, wfId, 1000, 999,
-                ImmutableWorkflowOptions.builder()
-                        .workflowConfigOverride(
-                                new WorkflowConfig()
-                                        .continueAsNewThreshold(1)
-                        )
-                        .build());
+                NoStateWorkflow.class, wfId, 1000, 999);
 
         final NoStateWorkflow rpcStub = client.newRpcStub(NoStateWorkflow.class, wfId, "");
 


### PR DESCRIPTION
### Description


### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Closes #<issue_number>
