### PR TITLE
IWF-248: change to use getMethods instead of getDeclaredMethods for R…

### DIFF
--- a/src/main/java/io/iworkflow/core/Registry.java
+++ b/src/main/java/io/iworkflow/core/Registry.java
@@ -89,7 +89,7 @@ public class Registry {
 
     private void registerWorkflowRPCs(final ObjectWorkflow wf) {
         String workflowType = getWorkflowType(wf);
-        final Method[] methods = wf.getClass().getDeclaredMethods();
+        final Method[] methods = wf.getClass().getMethods();
         if (methods.length == 0) {
             rpcMethodStore.put(workflowType, new HashMap<>());
             return;


### PR DESCRIPTION
…PC registration +pp @lexi @qlong @toms

### Description
Change how RPC methods are registered to work with inherited workflow classes

### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Closes #<issue_number>
