### PR TITLE
IWF-518: Bypass constructor when using newRpcStub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'io.swagger:swagger-core:1.6.6'
     implementation "org.openapitools:jackson-databind-nullable:0.2.1"
     implementation "net.bytebuddy:byte-buddy:1.14.4"
+    implementation "org.objenesis:objenesis:3.4"
 
     // jaskson
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"

--- a/src/main/java/io/iworkflow/core/Client.java
+++ b/src/main/java/io/iworkflow/core/Client.java
@@ -20,6 +20,8 @@ import io.iworkflow.gen.models.WorkflowStateOptions;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -802,21 +804,8 @@ public class Client {
                 .load(getClass().getClassLoader())
                 .getLoaded();
 
-        T result;
-        try {
-            if(dynamicType.getConstructors().length ==0){
-                throw new WorkflowDefinitionException("workflow must define at least a constructor");
-            }
-            final Constructor<?> constructor = dynamicType.getConstructors()[0];
-            final int parameterCount = constructor.getParameterCount();
-            final Object[] params = new Object[parameterCount];
-
-            result = (T) constructor.newInstance(params);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-            throw new IllegalStateException(e);
-        }
-
-        return result;
+        Objenesis objenesis = new ObjenesisStd();
+        return (T) objenesis.newInstance(dynamicType);
     }
 
     /**


### PR DESCRIPTION
### Description


### Checklist
- [x] Code compiles correctly
- [ ] Tests for the changes have been added
- [x] All tests passing
- [x] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Closes #259
