### PR TITLE
IWF-836: SDK expects stateWaitUntilFailed flag instead stateStartApiSucceeded 

### DIFF
--- a/src/main/java/io/iworkflow/core/mapper/CommandResultsMapper.java
+++ b/src/main/java/io/iworkflow/core/mapper/CommandResultsMapper.java
@@ -39,8 +39,13 @@ public class CommandResultsMapper {
                             objectEncoder))
                     .collect(Collectors.toList()));
         }
-        if(commandResults.getStateStartApiSucceeded() != null) {
-            builder.waitUntilApiSucceeded(commandResults.getStateStartApiSucceeded());
+
+        // The server will set stateWaitUntilFailed to true if the waitUntil API failed.
+        // Hence, flag inversion is needed here to indicate that the waitUntil API
+        // succeeded.
+        builder.waitUntilApiSucceeded(true);
+        if (Boolean.TRUE.equals(commandResults.getStateWaitUntilFailed())) {
+            builder.waitUntilApiSucceeded(false);
         }
         return builder.build();
     }


### PR DESCRIPTION
### Description
⚠️ Breaking change, requires iWF server version >= 1.18.0
SDK expects stateWaitUntilFailed flag instead stateStartApiSucceeded 

### Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added
- [x] All tests passing
- [ ] **This PR change is backwards-compatible**
- [x] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Addressing, but not yet closing https://github.com/indeedeng/iwf/issues/520, as we still need:
- Add changes for all SDKs
- Clean up old server fields (i.e. remove stateStartApiSucceeded field)