### PR TITLE
[NOBUG]Fix PersistenceOptions comment to remove RPC

### DIFF
--- a/src/main/java/io/iworkflow/core/persistence/PersistenceOptions.java
+++ b/src/main/java/io/iworkflow/core/persistence/PersistenceOptions.java
@@ -4,13 +4,11 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class PersistenceOptions {
-    // This option will enable caching persistence (data/search attributes) so that the readonly-RPC or GetDataAttributes API can
+    // This option will enable caching persistence (data/search attributes) so that GetDataAttributes and GetSearchAttributes API can
     // support a much higher throughput on a single workflow execution.
     // NOTES:
-    // 1. The read after write will become eventual consistent, unless set bypassCachingForStrongConsistency to true in RPC annotation
-    // 2. The caching is implemented by Temporal upsertMemo feature. Only iWF service with Temporal as backend is supporting this feature at the moment
-    // 3. It will extra cost as it will upsertMemo(WorkflowPropertiesModified event in the history) for write
-    // 4. Only useful for read-only RPC(no persistence.SetXXX API or communication API calls)
+    // 1. The caching is implemented by Temporal upsertMemo feature. Only iWF service with Temporal as backend supports this feature ATM.
+    // 2. It will cost extra action/event on updating data attribute, as iwf-server will upsertMemo(WorkflowPropertiesModified event in the history)
     public abstract boolean getEnableCaching();
 
     public static PersistenceOptions getDefault() {


### PR DESCRIPTION
### Description
Because RPC no longer use caching(describeWF) for loading data attributes after this PR: https://github.com/indeedeng/iwf/pull/502

### Checklist
- [ ] Code compiles correctly
- [ ] Tests for the changes have been added
- [ ] All tests passing
- [ ] **This PR change is backwards-compatible**
- [ ] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Closes #<issue_number>
